### PR TITLE
warp: fix crash when attempting to load old identity

### DIFF
--- a/warp/account.go
+++ b/warp/account.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -353,6 +354,10 @@ func LoadIdentity(path string) (Identity, error) {
 	err = json.Unmarshal(fileBytes, i)
 	if err != nil {
 		return Identity{}, err
+	}
+
+	if len(i.Config.Peers) < 1 {
+		return Identity{}, errors.New("identity contains 0 peers")
 	}
 
 	return *i, nil


### PR DESCRIPTION
When the old identity is encountered, just recreate.