### PR TITLE
enhancement: Add container image action (#72)

### DIFF
--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -1,0 +1,52 @@
+name: Container Image
+
+on:
+  push:
+    branches:
+      - master
+      - main
+    tags:
+      - v**
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build-publish:
+    name: Build and publish container image
+    runs-on: ubuntu-latest
+    env:
+      CGO_ENABLED: 0
+      PLATFORMS: linux/arm/v7,linux/arm64,linux/amd64
+    steps:
+      - name: Checkout codebase
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+          check-latest: true
+
+      - name: Setup `ko`
+        # The latest (@v0.6) version of this workflow has bug if there are uppercase letters in repo name
+        uses: ko-build/setup-ko@main
+
+      - name: Extract metadata
+        uses: docker/metadata-action@v5
+        id: meta
+        with:
+          # The images doesn't required, as only tags needed for the ko build step.
+          images: ""
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+            type=sha,format=long
+
+      - name: Build and push image
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: ko build --platform "${PLATFORMS}" --bare --tags $(echo $TAGS | tr ' ' ',')


### PR DESCRIPTION
## Description

Provide workflow to build and push the container image to GHCR automatically. (closes #72)

## Spec

### Archs

- `linux/arm/v7`
- `linux/arm64`
- `linux/amd64`

### Triggers

- Push to `main` and `master` branches. 
- Tags with `v**` prefix

### Tags

- `latest` and floating [semVer](https://semver.org/) tags
- Branch names
- SHA (short and long)

> examples available [here](https://github.com/debMan/warp-plus/pkgs/container/warp-plus)