### PR TITLE
feat: :sparkles: Add WithRoutingRuleConfig option to proxy (routing rules: Direct, Proxy, Block)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,18 +36,25 @@ NAME
   warp-plus
 
 FLAGS
-  -4                      only use IPv4 for random warp endpoint
-  -6                      only use IPv6 for random warp endpoint
-  -v, --verbose           enable verbose logging
-  -b, --bind STRING       socks bind address (default: 127.0.0.1:8086)
-  -e, --endpoint STRING   warp endpoint
-  -k, --key STRING        warp key
-      --gool              enable gool mode (warp in warp)
-      --cfon              enable psiphon mode (must provide country as well)
-      --country STRING    psiphon country code (valid values: [AT BE BG BR CA CH CZ DE DK EE ES FI FR GB HU IE IN IT JP LV NL NO PL RO RS SE SG SK UA US]) (default: AT)
-      --scan              enable warp scanning
-      --rtt DURATION      scanner rtt limit (default: 1s)
-  -c, --config STRING     path to config file
+  -4                       only use IPv4 for random warp endpoint
+  -6                       only use IPv6 for random warp endpoint
+  -v, --verbose            enable verbose logging
+  -b, --bind STRING        socks bind address (default: 127.0.0.1:8086)
+  -e, --endpoint STRING    warp endpoint
+  -k, --key STRING         warp key
+      --dns STRING         DNS address (default: 1.1.1.1)
+      --gool               enable gool mode (warp in warp)
+      --cfon               enable psiphon mode (must provide country as well)
+      --country STRING     psiphon country code (valid values: [AT BE BG BR CA CH CZ DE DK EE ES FI FR GB HR HU IE IN IT JP LV NL NO PL PT RO RS SE SG SK UA US]) (default: AT)
+      --scan               enable warp scanning
+      --rtt DURATION       scanner rtt limit (default: 1s)
+      --cache-dir STRING   directory to store generated profiles
+      --tun-experimental   enable tun interface (experimental)
+      --fwmark UINT        set linux firewall mark for tun mode (default: 4981)
+      --wgconf STRING      path to a normal wireguard config
+      --routing STRING     path to routing rule config file
+  -c, --config STRING      path to config file
+      --version            displays version number
 ```
 
 ### Country Codes for Psiphon

--- a/example_routing_rule_config.json
+++ b/example_routing_rule_config.json
@@ -1,0 +1,16 @@
+[
+  {
+    "type": "Direct",
+    "ip_list":["127.0.0.1"],
+    "cidr_list":["127.0.0.1/24", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"],
+    "domain_list":["digikala.com"],
+    "domain_regexp_list":[".*\\.ir$", ".*\\.iran$", ".*\\.aparat.com$"]
+  },
+  {
+    "type": "Block",
+    "ip_list":[],
+    "cidr_list":[],
+    "domain_list":["4fcom.top"],
+    "domain_regexp_list":[]
+  }
+]

--- a/proxy/example/customHandler/main.go
+++ b/proxy/example/customHandler/main.go
@@ -7,6 +7,7 @@ import (
 	"net"
 
 	"github.com/bepass-org/warp-plus/proxy/pkg/mixed"
+	"github.com/bepass-org/warp-plus/proxy/pkg/routing"
 	"github.com/bepass-org/warp-plus/proxy/pkg/statute"
 )
 
@@ -14,6 +15,17 @@ func main() {
 	proxy := mixed.NewProxy(
 		mixed.WithBindAddress("127.0.0.1:1080"),
 		mixed.WithUserHandler(generalHandler),
+		mixed.WithRoutingRuleConfig( // optional
+			routing.NewRoutingRuleConfig(
+				routing.RoutingRuleRawConfig{
+					RouteRuleType:    routing.DirectRoutingRule,
+					IpList:           []string{"172.16.0.1"},
+					CidrList:         []string{"127.0.0.1/24", "10.0.0.0/8", "192.168.0.0/16"},
+					DomainList:       []string{"example.com"},
+					DomainRegexpList: []string{`.*\.ir$`},
+				},
+			),
+		),
 	)
 	_ = proxy.ListenAndServe()
 }

--- a/proxy/pkg/mixed/handlers.go
+++ b/proxy/pkg/mixed/handlers.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net"
 
+	"github.com/bepass-org/warp-plus/proxy/pkg/routing"
 	"github.com/bepass-org/warp-plus/proxy/pkg/statute"
 )
 
@@ -96,5 +97,13 @@ func WithBytesPool(bytesPool statute.BytesPool) Option {
 		p.socks5Proxy.BytesPool = bytesPool
 		p.socks4Proxy.BytesPool = bytesPool
 		p.httpProxy.BytesPool = bytesPool
+	}
+}
+
+func WithRoutingRuleConfig(routeConfig ...*routing.RoutingRuleConfig) Option {
+	return func(p *Proxy) {
+		p.socks5Proxy.RoutingRuleList = append(p.socks5Proxy.RoutingRuleList, routeConfig...)
+		p.socks4Proxy.RoutingRuleList = append(p.socks4Proxy.RoutingRuleList, routeConfig...)
+		p.httpProxy.RoutingRuleList = append(p.httpProxy.RoutingRuleList, routeConfig...)
 	}
 }

--- a/proxy/pkg/routing/route_config.go
+++ b/proxy/pkg/routing/route_config.go
@@ -1,0 +1,149 @@
+package routing
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"regexp"
+)
+
+type RoutingRuleType string
+
+const (
+	ProxyRoutingRule  RoutingRuleType = "Proxy"
+	DirectRoutingRule RoutingRuleType = "Direct"
+	BlockRoutingRule  RoutingRuleType = "Block"
+)
+const domainRegexPattern = `^([A-Za-z0-9-]{1,63}\.)+[A-Za-z]{2,6}$`
+
+var ErrBlockRoutingRule = errors.New("block routing rule")
+
+var domainRegex = regexp.MustCompile(domainRegexPattern)
+
+type RoutingRuleConfig struct {
+	routeRuleType    RoutingRuleType
+	ipList           []*net.IP
+	cidrList         []*net.IPNet
+	domainList       []string
+	domainRegexpList []*regexp.Regexp
+}
+
+type RoutingRuleRawConfig struct {
+	RouteRuleType    RoutingRuleType `json:"type"`
+	IpList           []string        `json:"ip_list"`
+	CidrList         []string        `json:"cidr_list"`
+	DomainList       []string        `json:"domain_list"`
+	DomainRegexpList []string        `json:"domain_regexp_list"`
+}
+
+func NewRoutingRuleConfig(
+	routingRuleRawConfig RoutingRuleRawConfig,
+) *RoutingRuleConfig {
+
+	if !(routingRuleRawConfig.RouteRuleType == ProxyRoutingRule ||
+		routingRuleRawConfig.RouteRuleType == DirectRoutingRule ||
+		routingRuleRawConfig.RouteRuleType == BlockRoutingRule) {
+
+		panic(fmt.Sprintf(
+			"invalid routing type: %s, use these types: %s,%s,%s",
+			routingRuleRawConfig.RouteRuleType,
+			ProxyRoutingRule, DirectRoutingRule,
+			BlockRoutingRule,
+		))
+	}
+
+	rc := &RoutingRuleConfig{routeRuleType: routingRuleRawConfig.RouteRuleType}
+
+	// Parse IP addresses
+	for _, ipStr := range routingRuleRawConfig.IpList {
+		ip := net.ParseIP(ipStr)
+		if ip != nil {
+			rc.ipList = append(rc.ipList, &ip)
+		}
+	}
+
+	// Parse CIDR blocks
+	for _, cidrStr := range routingRuleRawConfig.CidrList {
+		_, cidr, err := net.ParseCIDR(cidrStr)
+		if err == nil {
+			rc.cidrList = append(rc.cidrList, cidr)
+		}
+	}
+
+	// Parse domain names
+	for _, domainStr := range routingRuleRawConfig.DomainList {
+		if host, _, err := net.SplitHostPort(domainStr); err == nil {
+			domainStr = host
+		}
+		rc.domainList = append(rc.domainList, domainStr)
+	}
+
+	// Compile regular expressions
+	for _, regexStr := range routingRuleRawConfig.DomainRegexpList {
+		if compiledRegex, err := regexp.Compile(regexStr); err == nil {
+			rc.domainRegexpList = append(rc.domainRegexpList, compiledRegex)
+		} else {
+			fmt.Println(err)
+		}
+	}
+
+	return rc
+}
+
+func GetRoutingRule(routeConfigList []*RoutingRuleConfig, Destination string) RoutingRuleType {
+	for _, routeConfig := range routeConfigList {
+		if routeConfig.Contains(Destination) {
+			return routeConfig.routeRuleType
+		}
+	}
+	return ""
+}
+
+func (rc *RoutingRuleConfig) Contains(Destination string) bool {
+
+	if Host, _, err := net.SplitHostPort(Destination); err == nil {
+		Destination = Host
+	}
+
+	if ip := net.ParseIP(Destination); ip != nil {
+		return rc.containsIP(ip)
+	}
+
+	if domainRegex.MatchString(Destination) {
+		return rc.containsDomain(Destination) || rc.containsDomainRegexp(Destination)
+	}
+
+	return false
+}
+
+func (rc *RoutingRuleConfig) containsIP(Destination net.IP) bool {
+	for _, netIP := range rc.ipList {
+		if netIP.Equal(Destination) {
+			return true
+		}
+	}
+	for _, cidr := range rc.cidrList {
+		if cidr.Contains(Destination) {
+			return true
+		}
+	}
+	return false
+}
+
+func (rc *RoutingRuleConfig) containsDomain(destinationHost string) bool {
+	for _, domain := range rc.domainList {
+		if domain == destinationHost {
+			return true
+		}
+	}
+	return false
+}
+
+func (rc *RoutingRuleConfig) containsDomainRegexp(Destination string) bool {
+	for _, domainRegexp := range rc.domainRegexpList {
+		if domainRegexp.MatchString(Destination) {
+			return true
+		}
+	}
+	return false
+}

--- a/proxy/pkg/routing/route_config_test.go
+++ b/proxy/pkg/routing/route_config_test.go
@@ -1,0 +1,153 @@
+package routing
+
+import (
+	"testing"
+)
+
+func TestRoutingRuleContains(t *testing.T) {
+
+	testRoutingConfig := NewRoutingRuleConfig(
+		RoutingRuleRawConfig{
+			RouteRuleType:    DirectRoutingRule,
+			IpList:           []string{"192.168.1.1"},
+			CidrList:         []string{"10.0.0.0/24"},
+			DomainList:       []string{"example.com"},
+			DomainRegexpList: []string{`^.*\.example\.com$`, `.*\.digikala\.com$`},
+		},
+	)
+	// Define test cases
+	testCases := []struct {
+		name        string
+		routeConfig *RoutingRuleConfig
+		destination string
+		expected    bool
+	}{
+		// Test cases for IP addresses
+		{
+			name:        "IP in IP list",
+			routeConfig: testRoutingConfig,
+			destination: "192.168.1.1",
+			expected:    true,
+		},
+		{
+			name:        "IP in IP list",
+			routeConfig: testRoutingConfig,
+			destination: "192.168.1.1:443",
+			expected:    true,
+		},
+		{
+			name:        "IP in IP list",
+			routeConfig: testRoutingConfig,
+			destination: "192.168.1.1:80",
+			expected:    true,
+		},
+		{
+			name:        "IP in CIDR list",
+			routeConfig: testRoutingConfig,
+			destination: "10.0.0.5",
+			expected:    true,
+		},
+		{
+			name:        "IP in CIDR list",
+			routeConfig: testRoutingConfig,
+			destination: "10.0.0.5:443",
+			expected:    true,
+		},
+		{
+			name:        "IP not in lists",
+			routeConfig: testRoutingConfig,
+			destination: "172.16.0.1",
+			expected:    false,
+		},
+		{
+			name:        "IP not in lists",
+			routeConfig: testRoutingConfig,
+			destination: "172.16.0.1:80",
+			expected:    false,
+		},
+		{
+			name:        "IP not in lists",
+			routeConfig: testRoutingConfig,
+			destination: "172.16.0.1",
+			expected:    false,
+		},
+		{
+			name:        "Invalid IP",
+			routeConfig: testRoutingConfig,
+			destination: "256.256.256.256",
+			expected:    false,
+		},
+		// Test cases for domain names
+		{
+			name:        "Domain in domain list",
+			routeConfig: testRoutingConfig,
+			destination: "example.com",
+			expected:    true,
+		},
+		{
+			name:        "Domain matching regex",
+			routeConfig: testRoutingConfig,
+			destination: "subdomain.example.com",
+			expected:    true,
+		},
+		{
+			name:        "Domain not in lists",
+			routeConfig: testRoutingConfig,
+			destination: "example.net:443",
+			expected:    false,
+		},
+		{
+			name:        "Invalid domain",
+			routeConfig: testRoutingConfig,
+			destination: "invalid",
+			expected:    false,
+		},
+		// Test cases for regular expressions
+		{
+			name:        "Destination matches regex",
+			routeConfig: testRoutingConfig,
+			destination: "prefix.example.com",
+			expected:    true,
+		},
+		{
+			name:        "Destination matches regex",
+			routeConfig: testRoutingConfig,
+			destination: "a.digikala.com",
+			expected:    true,
+		},
+		{
+			name:        "Destination matches regex",
+			routeConfig: testRoutingConfig,
+			destination: "test.example.com:443",
+			expected:    true,
+		},
+		{
+			name:        "Destination does not match regex",
+			routeConfig: testRoutingConfig,
+			destination: "digikala.com:80",
+			expected:    false,
+		},
+		{
+			name:        "Destination does not match regex",
+			routeConfig: testRoutingConfig,
+			destination: "test.digikala.com.invalid.com",
+			expected:    false,
+		},
+		{
+			name:        "Destination does not match regex",
+			routeConfig: testRoutingConfig,
+			destination: "anotherexample.com",
+			expected:    false,
+		},
+	}
+
+	// Run test cases
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.routeConfig.Contains(tc.destination)
+			if actual != tc.expected {
+				t.Errorf("Expected %v, got %v for destination %s", tc.expected, actual, tc.destination)
+			}
+		})
+	}
+}

--- a/proxy/pkg/socks5/server.go
+++ b/proxy/pkg/socks5/server.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net"
 
+	"github.com/bepass-org/warp-plus/proxy/pkg/routing"
 	"github.com/bepass-org/warp-plus/proxy/pkg/statute"
 )
 
@@ -36,6 +37,8 @@ type Server struct {
 	Context context.Context
 	// BytesPool getting and returning temporary bytes for use by io.CopyBuffer
 	BytesPool statute.BytesPool
+	// Routing Config
+	RoutingRuleList []*routing.RoutingRuleConfig
 }
 
 func NewServer(options ...ServerOption) *Server {
@@ -46,6 +49,7 @@ func NewServer(options ...ServerOption) *Server {
 		PacketForwardAddress: defaultReplyPacketForwardAddress,
 		Logger:               slog.Default(),
 		Context:              statute.DefaultContext(),
+		RoutingRuleList:      []*routing.RoutingRuleConfig{},
 	}
 
 	for _, option := range options {
@@ -157,6 +161,12 @@ func WithBytesPool(bytesPool statute.BytesPool) ServerOption {
 	}
 }
 
+func WithRoutingRuleConfig(routeConfig ...*routing.RoutingRuleConfig) ServerOption {
+	return func(p *Server) {
+		p.RoutingRuleList = append(p.RoutingRuleList, routeConfig...)
+	}
+}
+
 func (s *Server) ServeConn(conn net.Conn) error {
 	version, err := readByte(conn)
 	if err != nil {
@@ -235,7 +245,14 @@ func (s *Server) handle(req *request) error {
 }
 
 func (s *Server) handleConnect(req *request) error {
-	if s.UserConnectHandle == nil {
+
+	routingRuleType := routing.GetRoutingRule(s.RoutingRuleList, req.DestinationAddr.String())
+	if routingRuleType == routing.BlockRoutingRule {
+		s.Logger.Info("drop connection, (Block Routing Rule)", "Destination", req.DestinationAddr.String())
+		return routing.ErrBlockRoutingRule
+	}
+
+	if s.UserConnectHandle == nil || routingRuleType == routing.DirectRoutingRule {
 		return s.embedHandleConnect(req)
 	}
 

--- a/wiresocks/proxy.go
+++ b/wiresocks/proxy.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/bepass-org/warp-plus/proxy/pkg/mixed"
+	"github.com/bepass-org/warp-plus/proxy/pkg/routing"
 	"github.com/bepass-org/warp-plus/proxy/pkg/statute"
 	"github.com/bepass-org/warp-plus/wireguard/device"
 	"github.com/bepass-org/warp-plus/wireguard/tun/netstack"
@@ -26,7 +27,7 @@ type VirtualTun struct {
 }
 
 // StartProxy spawns a socks5 server.
-func StartProxy(ctx context.Context, l *slog.Logger, tnet *netstack.Net, bindAddress netip.AddrPort) (netip.AddrPort, error) {
+func StartProxy(ctx context.Context, l *slog.Logger, tnet *netstack.Net, bindAddress netip.AddrPort, routeConfig ...*routing.RoutingRuleConfig) (netip.AddrPort, error) {
 	ln, err := net.Listen("tcp", bindAddress.String())
 	if err != nil {
 		return netip.AddrPort{}, err // Return error if binding was unsuccessful
@@ -47,6 +48,7 @@ func StartProxy(ctx context.Context, l *slog.Logger, tnet *netstack.Net, bindAdd
 		mixed.WithUserHandler(func(request *statute.ProxyRequest) error {
 			return vt.generalHandler(request)
 		}),
+		mixed.WithRoutingRuleConfig(routeConfig...),
 	)
 	go func() {
 		_ = proxy.ListenAndServe()


### PR DESCRIPTION
This commit introduces the WithRoutingRuleConfig option to the proxy functionality. With this option, users can configure routing rules using IP addresses, CIDR blocks, domains, and regular expressions. Additionally, users can specify whether traffic matching these rules should be directed to a proxy, sent directly, or blocked altogether.