### PR TITLE
actions: support build for mips-softfloat devices

### DIFF
--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -39,6 +39,17 @@ jobs:
             goarch: mips
           - goos: linux
             goarch: mipsle
+          - goos: linux
+            goarch: mips64
+            gomips: softfloat
+          - goos: linux
+            goarch: mips64le
+            gomips: softfloat
+          - goos: linux
+            goarch: mips
+            gomips: softfloat
+          - goos: linux
+            goarch: mipsle
             gomips: softfloat
 
           - goos: windows

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -53,7 +53,7 @@ jobs:
       GOOS: ${{ matrix.goos }}
       GOARCH: ${{ matrix.goarch }}
       GOARM: ${{ matrix.goarm }}
-      GOMIPS: ${ matrix.gomips }
+      GOMIPS: ${{ matrix.gomips }}
       CGO_ENABLED: 0
     steps:
       - name: Checkout codebase

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -39,6 +39,7 @@ jobs:
             goarch: mips
           - goos: linux
             goarch: mipsle
+            gomips: softfloat
 
           - goos: windows
             goarch: amd64
@@ -52,6 +53,7 @@ jobs:
       GOOS: ${{ matrix.goos }}
       GOARCH: ${{ matrix.goarch }}
       GOARM: ${{ matrix.goarm }}
+      GOMIPS: ${ matrix.gomips }
       CGO_ENABLED: 0
     steps:
       - name: Checkout codebase


### PR DESCRIPTION
Because most of mips devices(including mips,mipsle,mips64,mips64le) do not support hardfloat(default build method), some routers cannot run this program(#141).  
This change let github action can build softfloat bins for these devices.  