### PR TITLE
Fix android DNS issues by using Go's built-in DNS resolver

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -125,7 +125,7 @@ func runWireguard(ctx context.Context, l *slog.Logger, opts WarpOptions) error {
 		peer.KeepAlive = 3
 
 		// Try resolving if the endpoint is a domain
-		addr, err := iputils.ParseResolveAddressPort(peer.Endpoint, false)
+		addr, err := iputils.ParseResolveAddressPort(peer.Endpoint, false, opts.DnsAddr.String())
 		if err == nil {
 			peer.Endpoint = addr.String()
 		}


### PR DESCRIPTION
On android devices (with termux) warp-plus fails to resolve the hostname in wireguard config file. By using a custom resolver and Go's built-in DNS resolver this bug have been fixed.

command:
```bash
./warp-plus --wgconf wg.conf --bind '127.0.0.1:10808' --cache-dir $PWD
```